### PR TITLE
Make BeanConverter more intelligent

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
-addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings"      % "1.0.0")
+addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings"      % "1.1.0")
 
-addSbtPlugin("com.github.gseitz"                 % "sbt-release"           % "1.0.4")
+addSbtPlugin("com.github.gseitz"                 % "sbt-release"           % "1.0.6")
 addSbtPlugin("com.jsuereth"                      % "sbt-pgp"               % "1.0.1")
 addSbtPlugin("org.xerial.sbt"                    % "sbt-sonatype"          % "1.1")
 


### PR DESCRIPTION
BeanConverter can convert Java types to similar Scala types. It can wrap nullables into Options.