### PR TITLE
Dockerize tests for easy reproduction

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+**/target
+*.md
+.dockerignore
+.git
+.gitignore
+.travis.yml
+Dockerfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,7 @@
-language: scala
-scala:
-  - 2.12.4
-  - 2.11.12
-  - 2.10.7
-jdk:
-  - oraclejdk8
-
-branches:
-  only: master
-
+sudo: required
+services:
+  - docker
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION clean coverage test coverageReport
-
+  - ./test.sh
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM aa8y/sbt:1.0
+
+WORKDIR $APP_DIR
+
+# Cache the SBT JARs in a layer.
+USER docker
+RUN mkdir project
+COPY project/build.properties project/
+USER root
+RUN chown -R docker:docker project
+USER docker
+RUN sbt +update
+
+# Cache the project-specific JARs.
+COPY project/*.sbt ./project
+COPY *.sbt ./
+USER root
+RUN chown -R docker:docker .
+USER docker
+RUN sbt +update
+
+# Copy the rest of the files. dockerignore should skip the files we don't want.
+COPY . ./
+USER root
+RUN chown -R docker:docker .
+USER docker
+RUN sbt +compile
+RUN sbt +test:compile
+
+CMD ["sbt"]

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+docker build -t beanpuree .
+docker run --name beanpuree_test beanpuree sbt +coverage +test +coverageReport
+docker cp beanpuree_test:/usr/src/app/target ./target
+docker stop beanpuree_test
+docker rm beanpuree_test


### PR DESCRIPTION
Dockerization helps making the tests reproducible in all environments. That is because we create a Docker image (using a `Dockerfile`) with the ideal setup and a Docker container from the image with the ideal environment. That way all tests are always run in an ideal environment created from scratch. All you need is `docker` installed in your environment and you can run tests by running the `test.sh` script.